### PR TITLE
Improve the UI. Use scrollable area.

### DIFF
--- a/src/libs/JustFastUi/JustFastUi.cpp
+++ b/src/libs/JustFastUi/JustFastUi.cpp
@@ -10,13 +10,13 @@ JustFastUi::JustFastUi()
 {
     currentPath = std::filesystem::current_path();
 
-    int aviableSpace = std::filesystem::space(currentPath).available / 1e9;
+    int availableSpace = std::filesystem::space(currentPath).available / 1e9;
     int capacity = std::filesystem::space(currentPath).capacity / 1e9;
-    disk_space_available = float(aviableSpace) / float(capacity);
-    spaceInfo =
-      L"Free Space:" + std::to_wstring(aviableSpace) + L" GiB" + L" (Total:" + std::to_wstring(capacity) + L"GiB)";
+    diskSpaceAvailable = float(availableSpace) / float(capacity);
+    spaceInfo = L"Free Space:" + std::to_wstring(availableSpace) + L" GiB " +
+                L"(Total:" + std::to_wstring(capacity) + L"GiB)";
 
-    statusMessange = L"";
+    statusMessage = L"";
     statusSelected = L"0";
 
     Add(&currentFolder);
@@ -36,7 +36,7 @@ void JustFastUi::updateMainView(size_t cursorPosition)
         }
     } catch (std::filesystem::filesystem_error& error) {
         std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        statusMessange = converter.from_bytes(error.what());
+        statusMessage = converter.from_bytes(error.what());
         changePathAndUpdateViews(currentPath.parent_path());
     }
 }
@@ -122,7 +122,7 @@ void JustFastUi::performOperation(std::filesystem::path dest)
         updateAllUi();
     } catch (std::filesystem::filesystem_error& error) {
         std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        statusMessange = converter.from_bytes(error.what());
+        statusMessage = converter.from_bytes(error.what());
         changePathAndUpdateViews(currentPath.parent_path());
     }
 }
@@ -147,7 +147,7 @@ ftxui::Element JustFastUi::Render()
             gauge(0.5) | flex | size(WIDTH, EQUAL, 10),
             text(L"] "),
             text(spaceInfo),
-            text(statusMessange) | center | flex,
+            text(statusMessage) | center | flex,
             text(statusSelected + L" " + operationView)
         );
 

--- a/src/libs/JustFastUi/JustFastUi.cpp
+++ b/src/libs/JustFastUi/JustFastUi.cpp
@@ -133,12 +133,12 @@ ftxui::Element JustFastUi::Render()
     using namespace ftxui;
 
     auto current_path = text(to_wstring(currentPath.string()));
-
+      
     auto main_view =
         hbox(
-            parentFolder.Render(),
+            parentFolder.Render() | frame,
             separator(),
-            currentFolder.Render()
+            currentFolder.Render() | flex | frame
         );
 
     auto status_line =

--- a/src/libs/JustFastUi/JustFastUi.h
+++ b/src/libs/JustFastUi/JustFastUi.h
@@ -9,10 +9,10 @@ class JustFastUi : public ftxui::Component {
 
 private:
     std::function<void()> quit;
-    std::wstring spaceInfo, statusMessange, statusSelected, operationView;
+    std::wstring spaceInfo, statusMessage, statusSelected, operationView;
     std::filesystem::path currentPath;
     ftxui::Menu parentFolder, currentFolder;
-    float disk_space_available;
+    float diskSpaceAvailable;
     bool isShowingHiddenFile { false };
 
     void updateParentView();


### PR DESCRIPTION
Wrap the menu(s) into a 'frame'. This creates a scrollable area. It means
the user can navigate inside a list that is potentially larger than the
screen size.

This is useful when the user's screen is too small or its directory
contains too many files.

On top of that, make the panel on the right to be flexible.

Demo:
[![asciicast](https://asciinema.org/a/49rEj0FoYvutHR5Uece23O45W.svg)](https://asciinema.org/a/49rEj0FoYvutHR5Uece23O45W)