### PR TITLE
Failing building caused by a missing header

### DIFF
--- a/src/libs/JustFastUi/JustFastUi.cpp
+++ b/src/libs/JustFastUi/JustFastUi.cpp
@@ -1,5 +1,6 @@
 #include "JustFastUi.h"
 #include <ftxui/screen/string.hpp>
+#include <codecvt>
 #include <utility>
 #include <string>
 


### PR DESCRIPTION
Without that header the compiler on Windows throws and error about the line 40, that it doesn't recognize the std::wstring_convert and std::codecvt_utf8_utf16. This one header fixes the problem.