### PR TITLE
Sort files

### DIFF
--- a/src/libs/JustFastUi/JustFastUi.cpp
+++ b/src/libs/JustFastUi/JustFastUi.cpp
@@ -28,8 +28,8 @@ JustFastUi::JustFastUi(const JustFastOptions& options)
 
 void JustFastUi::updateMainView(size_t cursorPosition)
 {
-    std::vector<std::wstring> currentFolderFiles;
-    std::vector<std::wstring> currentFolderFolders;
+    std::vector<std::filesystem::path> currentFolderFiles;
+    std::vector<std::filesystem::path> currentFolderFolders;
 
     currentFolderEntries.clear();
     currentFolderSelected = cursorPosition;
@@ -39,10 +39,10 @@ void JustFastUi::updateMainView(size_t cursorPosition)
 
                 if(isSortFiles) {
                     if(p.is_directory()) {
-                        currentFolderFolders.emplace_back(p.path().filename().wstring());
+                        currentFolderFolders.emplace_back(p.path().filename());
                     }
                     else {
-                        currentFolderFiles.emplace_back(p.path().filename().wstring());
+                        currentFolderFiles.emplace_back(p.path().filename());
                     }
                 }
                 else {
@@ -60,26 +60,58 @@ void JustFastUi::updateMainView(size_t cursorPosition)
         std::sort(currentFolderFolders.begin(), currentFolderFolders.end());
 
         for (const auto& folder : currentFolderFolders) {
-            currentFolderEntries.emplace_back(folder);
+            currentFolderEntries.emplace_back(folder.wstring());
         }
 
         std::sort(currentFolderFiles.begin(), currentFolderFiles.end());
 
         for (const auto& file : currentFolderFiles) {
-            currentFolderEntries.emplace_back(file);
+            currentFolderEntries.emplace_back(file.wstring());
         }
     }
 }
 
 void JustFastUi::updateParentView()
 {
+    std::vector<std::filesystem::path> parentFolderFiles;
+    std::vector<std::filesystem::path> parrentFolderFolders;
+
     parentFolderEntries.clear();
     for (const auto& p : std::filesystem::directory_iterator(currentPath.parent_path())) {
         if (isShowingHiddenFile || p.path().filename().string()[0] != '.') {
-            parentFolderEntries.emplace_back(p.path().filename().wstring());
+
+            if(isSortFiles) {
+                if(p.is_directory()) {
+                    parrentFolderFolders.emplace_back(p.path().filename());
+                }
+                else {
+                    parentFolderFiles.emplace_back(p.path().filename());
+                }
+            }
+            else {
+                parentFolderEntries.emplace_back(p.path().filename().wstring());
+                if (p.path().filename() == currentPath.filename()) {
+                    parentFolderSelected = parentFolderEntries.size() - 1;
+                }
+            }
+
         }
-        if (p.path().filename() == currentPath.filename()) {
-            parentFolderSelected = parentFolderEntries.size() - 1;
+    }
+
+    if(isSortFiles) {
+        std::sort(parrentFolderFolders.begin(), parrentFolderFolders.end());
+
+        for (const auto& folder : parrentFolderFolders) {
+            parentFolderEntries.emplace_back(folder.wstring());
+            if (folder == currentPath.filename()) {
+                parentFolderSelected = parentFolderEntries.size() - 1;
+            }
+        }
+
+        std::sort(parentFolderFiles.begin(), parentFolderFiles.end());
+
+        for (const auto& file : parentFolderFiles) {
+            parentFolderEntries.emplace_back(file.wstring());
         }
     }
 }

--- a/src/libs/JustFastUi/JustFastUi.h
+++ b/src/libs/JustFastUi/JustFastUi.h
@@ -6,6 +6,7 @@
 
 struct JustFastOptions{
     bool showHiddenFiles;
+    bool sortFiles;
     std::filesystem::path path;
 };
 
@@ -23,6 +24,7 @@ private:
     ftxui::Component currentFolder = ftxui::Menu(&currentFolderEntries, &currentFolderSelected);
     float diskSpaceAvailable;
     bool isShowingHiddenFile; 
+    bool isSortFiles; 
 
     void updateParentView();
     void updateMainView(size_t = 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,7 @@ int main(int argc, char* argv[]) noexcept
         }
     }
     options.showHiddenFiles = cliResult["all"].as<bool>();
+    options.sortFiles = true;
 
     startJustFast(options);
 


### PR DESCRIPTION
This is the implementation of the sorting algorithm for files and folders. I tried following the usual way OS do it by sorting alphabetically first all the folders in the current path and then sorting all the files in the current path.

I feel like you did put an emphasis on speed and lightness in this application so I made sure this sorting system is an option that can be disabled using a boolean I added in the JustFastOptions object.

This is part of #18 